### PR TITLE
Update NOTICE.txt with corrected license links and additional entries

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12,7 +12,7 @@ Licensed under BSD-3-Clause (https://github.com/Kitware/CMake/blob/master/LICENS
 configparser (https://github.com/jaraco/configparser)
 Licensed under MIT (https://github.com/jaraco/configparser/blob/main/LICENSE)
 
-coverage (https://github.com/nedbat/coveragepy)
+coverage (https://pypi.org/project/coverage/)
 Licensed under Apache 2.0 (https://github.com/nedbat/coveragepy/blob/master/LICENSE.txt)
 
 cupy-cuda12x (https://github.com/cupy/cupy)
@@ -40,8 +40,11 @@ imageio (https://github.com/imageio/imageio)
 2014-2022, imageio developers
 Licensed under BSD-2-Clause (https://github.com/imageio/imageio/blob/master/LICENSE)
 
-logger (https://github.com/python/cpython/blob/main/Lib/logging/__init__.py)
-2025 Python Software Foundation
+libstdcxx-ng (https://anaconda.org/conda-forge/libstdcxx-ng)
+2009 Free Software Foundation, Inc.
+Licensed under GPL-3.0 (https://gcc.gnu.org/onlinedocs/libstdc++/manual/license.html)
+
+logger (https://github.com/python/cpython/blob/main/Lib/logging/)
 Licensed under MIT (https://pypi.org/project/logger/)
 
 matplotlib (https://github.com/matplotlib/matplotlib)
@@ -68,10 +71,10 @@ scipy (https://github.com/scipy/scipy)
 2001-2002 Enthought, Inc. 2003, SciPy Developers.
 Licensed under BSD-3-Clause (https://github.com/scipy/scipy/blob/main/LICENSE.txt)
 
-torch (https://github.com/pytorch/pytorch)
+torch (https://pypi.org/project/torch/)
 2016- Facebook, Inc (Adam Paszke); 2014- Facebook, Inc (Soumith Chintala); 2011-2014 Idiap Research Institute (Ronan Collobert); 2012-2014 Deepmind Technologies (Koray Kavukcuoglu); 2011-2012 NEC Laboratories America (Koray Kavukcuoglu); 2011-2013 NYU (Clement Farabet); 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston); 2006 Idiap Research Institute (Samy Bengio); 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz); 2016 Facebook Inc.; 2015 Google Inc.; 2015 Yangqing Jia; 2019-2020 Kakao Brain; 2022 Cruise LLC.; 2024 Tri Dao.
 Licensed under BSD-3-Clause (https://github.com/pytorch/pytorch/blob/main/LICENSE)
 
 tqdm (https://github.com/tqdm/tqdm)
 2013 noamraph
-Licensed under MPL-2.0 AND MIT (https://github.com/tqdm/tqdm/blob/master/LICENCE)
+Licensed under MIT (https://github.com/tqdm/tqdm/blob/master/LICENCE)


### PR DESCRIPTION
- Changed coverage link to point to PyPI.
- Added libstdcxx-ng with its license information.
- Updated logger link to the main logging repository.
- Changed torch link to point to PyPI.
- Updated tqdm license information to reflect MIT only.
