### PR TITLE
feat(us): add in-memory mesh construction for raysim

### DIFF
--- a/ultrasound-raytracing/CMakeLists.txt
+++ b/ultrasound-raytracing/CMakeLists.txt
@@ -27,6 +27,7 @@ include(SetupCUDA)
 # Build options
 option(BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
 option(BUILD_EXAMPLES "Build C++ examples" ON)
+option(BUILD_TESTING "Build C++ tests" OFF)
 
 # Add core C++ libraries
 add_subdirectory(csrc)
@@ -34,4 +35,9 @@ add_subdirectory(csrc)
 # Add C++ examples
 if(BUILD_EXAMPLES)
     add_subdirectory(examples/cpp)
+endif()
+
+if(BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests/cpp)
 endif()

--- a/ultrasound-raytracing/csrc/core/hitable.cpp
+++ b/ultrasound-raytracing/csrc/core/hitable.cpp
@@ -36,6 +36,23 @@
 
 namespace raysim {
 
+namespace {
+
+void normalise_normals(std::vector<float3>& normals) {
+  for (float3& normal : normals) {
+    const float normal_length = std::hypot(normal.x, normal.y, normal.z);
+    if (!std::isfinite(normal_length) || normal_length == 0.f) {
+      throw std::invalid_argument("Mesh: normals must be finite and non-zero");
+    }
+
+    normal.x /= normal_length;
+    normal.y /= normal_length;
+    normal.z /= normal_length;
+  }
+}
+
+}  // namespace
+
 Hitable::Hitable(uint32_t material_id) : material_id_(material_id) {}
 
 Sphere::Sphere(float3 center, float radius, uint32_t material_id)
@@ -191,17 +208,9 @@ Mesh::Mesh(std::vector<float3> vertices, std::vector<uint32_t> indices, std::vec
         normal.z += face_normal.z;
       }
     }
-
-    for (float3& normal : normals_) {
-      const float normal_length =
-          std::sqrt(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z);
-      if (normal_length > 0.f) {
-        normal.x /= normal_length;
-        normal.y /= normal_length;
-        normal.z /= normal_length;
-      }
-    }
   }
+
+  normalise_normals(normals_);
 
   aabb_min_ = vertices_.front();
   aabb_max_ = vertices_.front();

--- a/ultrasound-raytracing/csrc/core/hitable.cpp
+++ b/ultrasound-raytracing/csrc/core/hitable.cpp
@@ -17,8 +17,12 @@
 
 #include "raysim/core/hitable.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <mutex>
+#include <stdexcept>
 #include <string>
+#include <utility>
 
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
@@ -92,12 +96,12 @@ Mesh::Mesh(const std::string& file_name, uint32_t material_id) : Hitable(materia
                                                Assimp::Logger::Err);
   });
 
-  importer_ = std::make_shared<Assimp::Importer>();
+  Assimp::Importer importer;
 
-  auto scene = importer_->ReadFile(file_name, aiProcess_GenBoundingBoxes);
+  auto scene = importer.ReadFile(file_name, aiProcess_GenBoundingBoxes);
   if (!scene) {
     throw std::runtime_error(fmt::format(
-        "Loading of mesh `{}` failed with error `{}`", file_name, importer_->GetErrorString()));
+        "Loading of mesh `{}` failed with error `{}`", file_name, importer.GetErrorString()));
   }
 
   auto node = scene->mRootNode;
@@ -114,6 +118,28 @@ Mesh::Mesh(const std::string& file_name, uint32_t material_id) : Hitable(materia
 
   if (!mesh->HasNormals()) { throw std::runtime_error("Mesh: has no normals"); }
 
+  vertices_.reserve(mesh->mNumVertices);
+  normals_.reserve(mesh->mNumVertices);
+  for (unsigned int vertex_index = 0; vertex_index < mesh->mNumVertices; ++vertex_index) {
+    const auto& vertex = mesh->mVertices[vertex_index];
+    vertices_.push_back({vertex.x, vertex.y, vertex.z});
+
+    const auto& normal = mesh->mNormals[vertex_index];
+    normals_.push_back({normal.x, normal.y, normal.z});
+  }
+
+  indices_.resize(mesh->mNumFaces * 3);
+  for (unsigned int face_index = 0; face_index < mesh->mNumFaces; ++face_index) {
+    const aiFace* const face = &mesh->mFaces[face_index];
+    if (face->mNumIndices != 3) {
+      spdlog::warn("Mesh: only triangles supported, found a face with {} indices",
+                   face->mNumIndices);
+    }
+    indices_[face_index * 3 + 0] = face->mIndices[0];
+    indices_[face_index * 3 + 1] = face->mIndices[1];
+    indices_[face_index * 3 + 2] = face->mIndices[2];
+  }
+
   // Get the axis aligned bounding box
   aabb_min_.x = mesh->mAABB.mMin.x;
   aabb_min_.y = mesh->mAABB.mMin.y;
@@ -123,48 +149,97 @@ Mesh::Mesh(const std::string& file_name, uint32_t material_id) : Hitable(materia
   aabb_max_.z = mesh->mAABB.mMax.z;
 }
 
+Mesh::Mesh(std::vector<float3> vertices, std::vector<uint32_t> indices, std::vector<float3> normals,
+           uint32_t material_id)
+    : Hitable(material_id),
+      vertices_(std::move(vertices)),
+      indices_(std::move(indices)),
+      normals_(std::move(normals)) {
+  if (vertices_.empty()) { throw std::invalid_argument("Mesh: vertices must not be empty"); }
+  if (indices_.empty()) { throw std::invalid_argument("Mesh: indices must not be empty"); }
+  if (indices_.size() % 3 != 0) {
+    throw std::invalid_argument("Mesh: indices size must be a multiple of 3");
+  }
+
+  for (const uint32_t index : indices_) {
+    if (index >= vertices_.size()) {
+      throw std::invalid_argument("Mesh: index is out of range for vertices");
+    }
+  }
+
+  if (!normals_.empty() && normals_.size() != vertices_.size()) {
+    throw std::invalid_argument("Mesh: normals size must match vertices size");
+  }
+
+  if (normals_.empty()) {
+    normals_.resize(vertices_.size(), float3{0.f, 0.f, 0.f});
+    for (size_t index = 0; index < indices_.size(); index += 3) {
+      const float3& a = vertices_[indices_[index]];
+      const float3& b = vertices_[indices_[index + 1]];
+      const float3& c = vertices_[indices_[index + 2]];
+
+      const float3 edge_ab{b.x - a.x, b.y - a.y, b.z - a.z};
+      const float3 edge_ac{c.x - a.x, c.y - a.y, c.z - a.z};
+      const float3 face_normal{edge_ab.y * edge_ac.z - edge_ab.z * edge_ac.y,
+                               edge_ab.z * edge_ac.x - edge_ab.x * edge_ac.z,
+                               edge_ab.x * edge_ac.y - edge_ab.y * edge_ac.x};
+
+      for (size_t vertex = 0; vertex < 3; ++vertex) {
+        float3& normal = normals_[indices_[index + vertex]];
+        normal.x += face_normal.x;
+        normal.y += face_normal.y;
+        normal.z += face_normal.z;
+      }
+    }
+
+    for (float3& normal : normals_) {
+      const float normal_length =
+          std::sqrt(normal.x * normal.x + normal.y * normal.y + normal.z * normal.z);
+      if (normal_length > 0.f) {
+        normal.x /= normal_length;
+        normal.y /= normal_length;
+        normal.z /= normal_length;
+      }
+    }
+  }
+
+  aabb_min_ = vertices_.front();
+  aabb_max_ = vertices_.front();
+  for (const float3& vertex : vertices_) {
+    aabb_min_.x = std::min(aabb_min_.x, vertex.x);
+    aabb_min_.y = std::min(aabb_min_.y, vertex.y);
+    aabb_min_.z = std::min(aabb_min_.z, vertex.z);
+    aabb_max_.x = std::max(aabb_max_.x, vertex.x);
+    aabb_max_.y = std::max(aabb_max_.y, vertex.y);
+    aabb_max_.z = std::max(aabb_max_.z, vertex.z);
+  }
+}
+
 void Mesh::build(OptixBuildInput* optix_build_input, HitGroupData* hit_group_data,
                  cudaStream_t stream) {
-  auto scene = importer_->GetScene();
-  auto mesh = scene->mMeshes[scene->mRootNode->mChildren[0]->mMeshes[0]];
-
   optix_build_input->type = OPTIX_BUILD_INPUT_TYPE_TRIANGLES;
 
-  cuda_vertex_buffer_ =
-      std::make_unique<CudaMemory>(mesh->mNumVertices * sizeof(aiVector3D), stream);
-  cuda_vertex_buffer_->upload(mesh->mVertices, stream);
+  cuda_vertex_buffer_ = std::make_unique<CudaMemory>(vertices_.size() * sizeof(float3), stream);
+  cuda_vertex_buffer_->upload(vertices_.data(), stream);
 
   vertex_buffers_.push_back(cuda_vertex_buffer_->get_device_ptr(stream));
   optix_build_input->triangleArray.vertexBuffers = vertex_buffers_.data();
-  optix_build_input->triangleArray.numVertices = mesh->mNumVertices;
+  optix_build_input->triangleArray.numVertices = static_cast<uint32_t>(vertices_.size());
   optix_build_input->triangleArray.vertexFormat = OptixVertexFormat::OPTIX_VERTEX_FORMAT_FLOAT3;
 
-  std::vector<unsigned int> indices(mesh->mNumFaces * 3);
-  for (unsigned int face_index = 0; face_index < mesh->mNumFaces; ++face_index) {
-    const aiFace* const face = &mesh->mFaces[face_index];
-    if (face->mNumIndices != 3) {
-      spdlog::warn("Mesh: only triangles supported, found a face with {} indices",
-                   face->mNumIndices);
-    }
-    indices[face_index * 3 + 0] = face->mIndices[0];
-    indices[face_index * 3 + 1] = face->mIndices[1];
-    indices[face_index * 3 + 2] = face->mIndices[2];
-  }
-
-  cuda_index_buffer_ = std::make_unique<CudaMemory>(indices.size() * sizeof(unsigned int), stream);
-  cuda_index_buffer_->upload(indices.data(), stream);
+  cuda_index_buffer_ = std::make_unique<CudaMemory>(indices_.size() * sizeof(uint32_t), stream);
+  cuda_index_buffer_->upload(indices_.data(), stream);
 
   optix_build_input->triangleArray.indexBuffer = cuda_index_buffer_->get_device_ptr(stream);
-  optix_build_input->triangleArray.numIndexTriplets = indices.size() / 3;
+  optix_build_input->triangleArray.numIndexTriplets = static_cast<uint32_t>(indices_.size() / 3);
   optix_build_input->triangleArray.indexFormat =
       OptixIndicesFormat::OPTIX_INDICES_FORMAT_UNSIGNED_INT3;
 
   hit_group_data->indices =
       reinterpret_cast<uint32_t*>(optix_build_input->triangleArray.indexBuffer);
 
-  cuda_normal_buffer_ =
-      std::make_unique<CudaMemory>(mesh->mNumVertices * sizeof(aiVector3D), stream);
-  cuda_normal_buffer_->upload(mesh->mNormals, stream);
+  cuda_normal_buffer_ = std::make_unique<CudaMemory>(normals_.size() * sizeof(float3), stream);
+  cuda_normal_buffer_->upload(normals_.data(), stream);
   hit_group_data->normals = reinterpret_cast<float3*>(cuda_normal_buffer_->get_ptr(stream));
 
   sbt_flags_.push_back(OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT |

--- a/ultrasound-raytracing/csrc/python/raysim_bindings.cpp
+++ b/ultrasound-raytracing/csrc/python/raysim_bindings.cpp
@@ -18,13 +18,18 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <cstdint>
+#include <cstring>
 #include <iostream>
+#include <limits>
 
 #include <chrono>
 #include <filesystem>
 #include <iostream>
 #include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include <spdlog/spdlog.h>
 
@@ -59,6 +64,107 @@ py::array_t<float> float3_to_numpy(float3 vec) {
   ptr[1] = vec.y;
   ptr[2] = vec.z;
   return result;
+}
+
+py::array make_c_contiguous(const py::array& array, const char* name) {
+  auto contiguous = py::array::ensure(array, py::array::c_style);
+  if (!contiguous) {
+    throw py::value_error(std::string(name) + " could not be copied to a C-contiguous array");
+  }
+  return contiguous;
+}
+
+template <typename T>
+T read_array_value(const void* data, size_t index) {
+  T value;
+  std::memcpy(&value, static_cast<const char*>(data) + index * sizeof(T), sizeof(T));
+  return value;
+}
+
+std::vector<float3> numpy_to_float3_vector(const py::array& array, const char* name,
+                                           ssize_t expected_rows = -1) {
+  if (!array.dtype().is(py::dtype::of<float>())) {
+    throw py::value_error(std::string(name) + " must have dtype float32");
+  }
+  if (array.ndim() != 2 || array.shape(1) != 3) {
+    throw py::value_error(std::string(name) + " must have shape (N, 3)");
+  }
+  if (expected_rows >= 0 && array.shape(0) != expected_rows) {
+    throw py::value_error(std::string(name) + " must have the same number of rows as vertices");
+  }
+
+  auto contiguous = make_c_contiguous(array, name);
+  const auto buffer = contiguous.request();
+  std::vector<float3> result;
+  result.reserve(static_cast<size_t>(buffer.shape[0]));
+  for (ssize_t row = 0; row < buffer.shape[0]; ++row) {
+    const auto offset = static_cast<size_t>(3 * row);
+    result.push_back(make_float3(read_array_value<float>(buffer.ptr, offset),
+                                 read_array_value<float>(buffer.ptr, offset + 1),
+                                 read_array_value<float>(buffer.ptr, offset + 2)));
+  }
+  return result;
+}
+
+std::vector<uint32_t> numpy_to_triangle_indices(const py::array& array) {
+  if (array.ndim() != 2 || array.shape(1) != 3) {
+    throw py::value_error("indices must have shape (M, 3)");
+  }
+
+  const bool is_uint32 = array.dtype().is(py::dtype::of<uint32_t>());
+  const bool is_int32 = array.dtype().is(py::dtype::of<int32_t>());
+  const bool is_int64 = array.dtype().is(py::dtype::of<int64_t>());
+  if (!is_uint32 && !is_int32 && !is_int64) {
+    throw py::value_error("indices must have dtype uint32, int32, or int64");
+  }
+
+  auto contiguous = make_c_contiguous(array, "indices");
+  const auto buffer = contiguous.request();
+  const auto count = static_cast<size_t>(buffer.shape[0]) * 3;
+  std::vector<uint32_t> result;
+  result.reserve(count);
+
+  if (is_uint32) {
+    for (size_t index = 0; index < count; ++index) {
+      result.push_back(read_array_value<uint32_t>(buffer.ptr, index));
+    }
+    return result;
+  }
+
+  if (is_int32) {
+    for (size_t index = 0; index < count; ++index) {
+      const int32_t value = read_array_value<int32_t>(buffer.ptr, index);
+      if (value < 0) { throw py::value_error("indices must contain only non-negative values"); }
+      result.push_back(static_cast<uint32_t>(value));
+    }
+    return result;
+  }
+
+  for (size_t index = 0; index < count; ++index) {
+    const int64_t value = read_array_value<int64_t>(buffer.ptr, index);
+    if (value < 0) { throw py::value_error("indices must contain only non-negative values"); }
+    if (value > std::numeric_limits<uint32_t>::max()) {
+      throw py::value_error("indices values must fit in uint32");
+    }
+    result.push_back(static_cast<uint32_t>(value));
+  }
+  return result;
+}
+
+std::unique_ptr<raysim::Mesh> mesh_from_numpy(const py::array& vertices, const py::array& indices,
+                                              const py::object& normals, uint32_t material_id) {
+  auto mesh_vertices = numpy_to_float3_vector(vertices, "vertices");
+  auto mesh_indices = numpy_to_triangle_indices(indices);
+  std::vector<float3> mesh_normals;
+  if (!normals.is_none()) {
+    if (!py::isinstance<py::array>(normals)) {
+      throw py::value_error("normals must be a NumPy array or None");
+    }
+    mesh_normals = numpy_to_float3_vector(
+        py::reinterpret_borrow<py::array>(normals), "normals", vertices.shape(0));
+  }
+  return std::make_unique<raysim::Mesh>(
+      std::move(mesh_vertices), std::move(mesh_indices), std::move(mesh_normals), material_id);
 }
 
 PYBIND11_MODULE(ray_sim_python, m) {
@@ -564,7 +670,8 @@ Elements steer beams electronically to create a sector image from a small footpr
   py::class_<raysim::Mesh, raysim::Hitable>(m, "Mesh", R"pbdoc(
         Represents a 3D mesh object for ultrasound simulation.
 
-        The mesh is loaded from an OBJ file and assigned a material.
+        The mesh is loaded from a file or constructed from in-memory arrays and
+        assigned a material.
     )pbdoc")
       .def(py::init([](const std::string& file_name, uint32_t material_id) {
              spdlog::info(
@@ -586,6 +693,51 @@ Elements steer beams electronically to create a sector image from a small footpr
         Args:
             file_name (str): Path to OBJ file
             material_id (int): Material index from Materials.get_index()
+      )pbdoc")
+      .def(py::init([](const py::array& vertices,
+                       const py::array& indices,
+                       const py::object& normals,
+                       uint32_t material_id) {
+             return mesh_from_numpy(vertices, indices, normals, material_id);
+           }),
+           py::arg("vertices"),
+           py::arg("indices"),
+           py::arg("normals"),
+           py::arg("material_id"),
+           R"pbdoc(
+        Initialise a mesh from in-memory geometry.
+
+        Args:
+            vertices (np.ndarray): Vertex positions with shape (N, 3) and dtype float32.
+            indices (np.ndarray): Triangle indices with shape (M, 3) and dtype uint32,
+                int32, or int64.
+            normals (Optional[np.ndarray]): Per-vertex normals with shape (N, 3) and
+                dtype float32. If omitted, area-weighted normals are computed.
+            material_id (int): Material index from Materials.get_index().
+
+        Example:
+            >>> import numpy as np
+            >>> vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+            >>> indices = np.array([[0, 1, 2]], dtype=np.uint32)
+            >>> mesh = Mesh(vertices=vertices, indices=indices, material_id=0)
+
+        Geometry extracted from a UsdGeomMesh with usd-core can be passed directly after
+        triangulating its face indices host-side; raysim does not depend on usd-core.
+      )pbdoc")
+      .def(py::init([](const py::array& vertices, const py::array& indices, uint32_t material_id) {
+             return mesh_from_numpy(vertices, indices, py::none(), material_id);
+           }),
+           py::arg("vertices"),
+           py::arg("indices"),
+           py::arg("material_id"),
+           R"pbdoc(
+        Initialise a mesh from in-memory geometry and compute area-weighted vertex normals.
+
+        Args:
+            vertices (np.ndarray): Vertex positions with shape (N, 3) and dtype float32.
+            indices (np.ndarray): Triangle indices with shape (M, 3) and dtype uint32,
+                int32, or int64.
+            material_id (int): Material index from Materials.get_index().
       )pbdoc");
 
   // Bind Sphere class

--- a/ultrasound-raytracing/csrc/python/raysim_bindings.cpp
+++ b/ultrasound-raytracing/csrc/python/raysim_bindings.cpp
@@ -712,7 +712,8 @@ Elements steer beams electronically to create a sector image from a small footpr
             indices (np.ndarray): Triangle indices with shape (M, 3) and dtype uint32,
                 int32, or int64.
             normals (Optional[np.ndarray]): Per-vertex normals with shape (N, 3) and
-                dtype float32. If omitted, area-weighted normals are computed.
+                dtype float32. Supplied normals are normalised; if omitted, area-weighted
+                normals are computed.
             material_id (int): Material index from Materials.get_index().
 
         Example:

--- a/ultrasound-raytracing/include/raysim/core/hitable.hpp
+++ b/ultrasound-raytracing/include/raysim/core/hitable.hpp
@@ -21,14 +21,12 @@
 #include <optix_types.h>
 #include <vector_types.h>
 
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "raysim/cuda/cuda_helper.hpp"
-
-namespace Assimp {
-class Importer;
-}  // namespace Assimp
 
 namespace raysim {
 
@@ -79,12 +77,16 @@ class Sphere : public Hitable {
 class Mesh : public Hitable {
  public:
   Mesh(const std::string& file_name, uint32_t material_id);
+  Mesh(std::vector<float3> vertices, std::vector<uint32_t> indices, std::vector<float3> normals,
+       uint32_t material_id);
 
   void build(OptixBuildInput* optix_build_input, HitGroupData* hit_group_data,
              cudaStream_t stream) override;
 
  private:
-  std::shared_ptr<Assimp::Importer> importer_;
+  std::vector<float3> vertices_;
+  std::vector<uint32_t> indices_;
+  std::vector<float3> normals_;
 
   std::unique_ptr<CudaMemory> cuda_vertex_buffer_;
   std::unique_ptr<CudaMemory> cuda_index_buffer_;

--- a/ultrasound-raytracing/tests/conftest.py
+++ b/ultrasound-raytracing/tests/conftest.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pytest configuration for raysim tests."""
+
+
+def pytest_configure(config):
+    """Register markers used by the raysim test suite."""
+    config.addinivalue_line("markers", "gpu: mark test as requiring a CUDA-capable GPU")

--- a/ultrasound-raytracing/tests/cpp/CMakeLists.txt
+++ b/ultrasound-raytracing/tests/cpp/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_executable(mesh_test mesh_test.cpp)
+
+set_target_properties(mesh_test PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+)
+
+target_link_libraries(mesh_test PRIVATE ray_sim_core ray_sim_cuda)
+
+add_test(NAME mesh_test COMMAND mesh_test)

--- a/ultrasound-raytracing/tests/cpp/mesh_test.cpp
+++ b/ultrasound-raytracing/tests/cpp/mesh_test.cpp
@@ -1,0 +1,174 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "raysim/core/hitable.hpp"
+
+namespace {
+
+const std::vector<float3> kTriangleVertices = {
+    make_float3(0.0f, 0.0f, 0.0f),
+    make_float3(1.0f, 0.0f, 0.0f),
+    make_float3(0.0f, 1.0f, 0.0f),
+};
+
+const std::vector<uint32_t> kTriangleIndices = {0, 1, 2};
+
+class MeshWithoutNormalsFile {
+ public:
+  MeshWithoutNormalsFile()
+      : path_(std::filesystem::temp_directory_path() / "raysim_mesh_without_normals.obj") {
+    std::ofstream stream(path_);
+    stream << "o TriangleWithoutNormals\n"
+              "v 0.0 0.0 0.0\n"
+              "v 1.0 0.0 0.0\n"
+              "v 0.0 1.0 0.0\n"
+              "f 1 2 3\n";
+    if (!stream) { throw std::runtime_error("failed to write the normals-free mesh fixture"); }
+  }
+
+  ~MeshWithoutNormalsFile() {
+    std::error_code error;
+    std::filesystem::remove(path_, error);
+  }
+
+  const std::filesystem::path& path() const { return path_; }
+
+ private:
+  std::filesystem::path path_;
+};
+
+void require(bool condition, const char* message) {
+  if (!condition) { throw std::runtime_error(message); }
+}
+
+template <typename Callable>
+void require_invalid_argument(Callable&& callable, const char* message) {
+  try {
+    callable();
+  } catch (const std::invalid_argument&) { return; }
+
+  throw std::runtime_error(message);
+}
+
+void test_constructs_from_arrays_and_computes_aabb() {
+  const std::vector<float3> vertices = {
+      make_float3(-1.0f, -2.0f, -3.0f),
+      make_float3(4.0f, -2.0f, -3.0f),
+      make_float3(-1.0f, 5.0f, -3.0f),
+      make_float3(-1.0f, -2.0f, 6.0f),
+  };
+  const std::vector<uint32_t> indices = {
+      0,
+      2,
+      1,
+      0,
+      1,
+      3,
+      0,
+      3,
+      2,
+      1,
+      2,
+      3,
+  };
+
+  const raysim::Mesh mesh(vertices, indices, {}, 3);
+
+  const float3 aabb_min = mesh.get_aabb_min();
+  require(aabb_min.x == -1.0f, "unexpected AABB minimum x component");
+  require(aabb_min.y == -2.0f, "unexpected AABB minimum y component");
+  require(aabb_min.z == -3.0f, "unexpected AABB minimum z component");
+
+  const float3 aabb_max = mesh.get_aabb_max();
+  require(aabb_max.x == 4.0f, "unexpected AABB maximum x component");
+  require(aabb_max.y == 5.0f, "unexpected AABB maximum y component");
+  require(aabb_max.z == 6.0f, "unexpected AABB maximum z component");
+}
+
+void test_rejects_empty_vertices() {
+  require_invalid_argument([]() { raysim::Mesh({}, kTriangleIndices, {}, 0); },
+                           "empty vertices were accepted");
+}
+
+void test_rejects_empty_indices() {
+  require_invalid_argument([]() { raysim::Mesh(kTriangleVertices, {}, {}, 0); },
+                           "empty indices were accepted");
+}
+
+void test_rejects_an_incomplete_triangle() {
+  require_invalid_argument([]() { raysim::Mesh(kTriangleVertices, {0, 1}, {}, 0); },
+                           "an incomplete triangle was accepted");
+}
+
+void test_rejects_an_out_of_range_index() {
+  require_invalid_argument([]() { raysim::Mesh(kTriangleVertices, {0, 1, 3}, {}, 0); },
+                           "an out-of-range index was accepted");
+}
+
+void test_rejects_the_wrong_number_of_normals() {
+  const std::vector<float3> normals = {
+      make_float3(0.0f, 0.0f, 1.0f),
+      make_float3(0.0f, 0.0f, 1.0f),
+  };
+
+  require_invalid_argument(
+      [&normals]() { raysim::Mesh(kTriangleVertices, kTriangleIndices, normals, 0); },
+      "the wrong number of normals was accepted");
+}
+
+void test_file_constructor_still_rejects_a_mesh_without_normals() {
+  const MeshWithoutNormalsFile file;
+
+  bool rejected = false;
+  try {
+    const raysim::Mesh mesh(file.path().string(), 0);
+  } catch (const std::runtime_error& error) {
+    require(std::string(error.what()) == "Mesh: has no normals",
+            "the normals-free mesh produced an unexpected error");
+    rejected = true;
+  }
+
+  require(rejected, "the normals-free mesh was accepted");
+}
+
+}  // namespace
+
+int main() {
+  try {
+    test_constructs_from_arrays_and_computes_aabb();
+    test_rejects_empty_vertices();
+    test_rejects_empty_indices();
+    test_rejects_an_incomplete_triangle();
+    test_rejects_an_out_of_range_index();
+    test_rejects_the_wrong_number_of_normals();
+    test_file_constructor_still_rejects_a_mesh_without_normals();
+  } catch (const std::exception& exception) {
+    std::cerr << "mesh test failed: " << exception.what() << '\n';
+    return 1;
+  }
+
+  std::cout << "mesh test passed\n";
+  return 0;
+}

--- a/ultrasound-raytracing/tests/cpp/mesh_test.cpp
+++ b/ultrasound-raytracing/tests/cpp/mesh_test.cpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -138,6 +139,31 @@ void test_rejects_the_wrong_number_of_normals() {
       "the wrong number of normals was accepted");
 }
 
+void test_rejects_zero_length_normals() {
+  const std::vector<float3> normals(kTriangleVertices.size(), make_float3(0.0f, 0.0f, 0.0f));
+
+  require_invalid_argument(
+      [&normals]() { raysim::Mesh(kTriangleVertices, kTriangleIndices, normals, 0); },
+      "zero-length normals were accepted");
+}
+
+void test_rejects_non_finite_normals() {
+  std::vector<float3> normals(kTriangleVertices.size(), make_float3(0.0f, 0.0f, 1.0f));
+  normals.front().x = std::numeric_limits<float>::quiet_NaN();
+
+  require_invalid_argument(
+      [&normals]() { raysim::Mesh(kTriangleVertices, kTriangleIndices, normals, 0); },
+      "a non-finite normal was accepted");
+}
+
+void test_rejects_cancelling_generated_normals() {
+  const std::vector<uint32_t> opposing_indices = {0, 1, 2, 0, 2, 1};
+
+  require_invalid_argument(
+      [&opposing_indices]() { raysim::Mesh(kTriangleVertices, opposing_indices, {}, 0); },
+      "cancelling generated normals were accepted");
+}
+
 void test_file_constructor_still_rejects_a_mesh_without_normals() {
   const MeshWithoutNormalsFile file;
 
@@ -163,6 +189,9 @@ int main() {
     test_rejects_an_incomplete_triangle();
     test_rejects_an_out_of_range_index();
     test_rejects_the_wrong_number_of_normals();
+    test_rejects_zero_length_normals();
+    test_rejects_non_finite_normals();
+    test_rejects_cancelling_generated_normals();
     test_file_constructor_still_rejects_a_mesh_without_normals();
   } catch (const std::exception& exception) {
     std::cerr << "mesh test failed: " << exception.what() << '\n';

--- a/ultrasound-raytracing/tests/test_mesh.py
+++ b/ultrasound-raytracing/tests/test_mesh.py
@@ -194,6 +194,32 @@ def test_array_constructor_rejects_empty_geometry(vertices, indices, message):
         rs.Mesh(vertices=vertices, indices=indices, material_id=0)
 
 
+@pytest.mark.parametrize(
+    "invalid_normal",
+    [
+        np.array([0.0, 0.0, 0.0], dtype=np.float32),
+        np.array([np.nan, 0.0, 1.0], dtype=np.float32),
+    ],
+    ids=["zero-length", "non-finite"],
+)
+def test_array_constructor_rejects_invalid_normals(invalid_normal):
+    vertices, indices, normals = octahedron_geometry()
+    normals[0] = invalid_normal
+
+    with pytest.raises(ValueError, match="Mesh: normals must be finite and non-zero"):
+        rs.Mesh(vertices=vertices, indices=indices, normals=normals, material_id=0)
+
+
+def test_array_constructor_rejects_cancelling_generated_normals():
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32
+    )
+    indices = np.array([[0, 1, 2], [0, 2, 1]], dtype=np.uint32)
+
+    with pytest.raises(ValueError, match="Mesh: normals must be finite and non-zero"):
+        rs.Mesh(vertices=vertices, indices=indices, material_id=0)
+
+
 def write_obj(file_name, vertices, indices, normals):
     """Write geometry without changing its vertex or normal indexing."""
     lines = ["o Octahedron"]
@@ -243,7 +269,7 @@ def test_array_and_file_meshes_render_identically(tmp_path):
         lambda material_id: rs.Mesh(
             vertices=vertices,
             indices=indices,
-            normals=normals,
+            normals=normals * np.float32(7.0),
             material_id=material_id,
         )
     )

--- a/ultrasound-raytracing/tests/test_mesh.py
+++ b/ultrasound-raytracing/tests/test_mesh.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for constructing raysim meshes from NumPy arrays."""
+
+import numpy as np
+import pytest
+import raysim.cuda as rs
+
+
+def octahedron_geometry():
+    """Return a closed octahedron centred in front of the probe."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, -60.0],
+            [20.0, 0.0, -80.0],
+            [0.0, 20.0, -80.0],
+            [-20.0, 0.0, -80.0],
+            [0.0, -20.0, -80.0],
+            [0.0, 0.0, -100.0],
+        ],
+        dtype=np.float32,
+    )
+    indices = np.array(
+        [
+            [0, 1, 2],
+            [0, 2, 3],
+            [0, 3, 4],
+            [0, 4, 1],
+            [5, 2, 1],
+            [5, 3, 2],
+            [5, 4, 3],
+            [5, 1, 4],
+        ],
+        dtype=np.uint32,
+    )
+    normals = np.array(
+        [
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [0.0, 0.0, -1.0],
+        ],
+        dtype=np.float32,
+    )
+    return vertices, indices, normals
+
+
+@pytest.mark.parametrize("index_dtype", [np.uint32, np.int32, np.int64])
+def test_array_constructor_accepts_supported_index_dtypes(index_dtype):
+    vertices, indices, normals = octahedron_geometry()
+
+    mesh = rs.Mesh(
+        vertices=vertices,
+        indices=indices.astype(index_dtype),
+        normals=normals,
+        material_id=0,
+    )
+
+    np.testing.assert_array_equal(mesh.get_aabb_min(), [-20.0, -20.0, -100.0])
+    np.testing.assert_array_equal(mesh.get_aabb_max(), [20.0, 20.0, -60.0])
+
+
+def test_array_constructor_copies_non_contiguous_inputs():
+    vertices, indices, normals = octahedron_geometry()
+    vertices = np.asfortranarray(vertices)
+    indices = np.asfortranarray(indices)
+    normals = np.asfortranarray(normals)
+
+    mesh = rs.Mesh(
+        vertices=vertices,
+        indices=indices,
+        normals=normals,
+        material_id=0,
+    )
+
+    np.testing.assert_array_equal(mesh.get_aabb_min(), [-20.0, -20.0, -100.0])
+    np.testing.assert_array_equal(mesh.get_aabb_max(), [20.0, 20.0, -60.0])
+
+
+def unaligned_copy(array):
+    """Copy an array to a C-contiguous buffer with an unaligned data pointer."""
+    storage = np.empty(array.nbytes + 1, dtype=np.uint8)
+    result = np.ndarray(array.shape, dtype=array.dtype, buffer=storage, offset=1)
+    result[...] = array
+    assert result.flags.c_contiguous
+    assert not result.flags.aligned
+    return result
+
+
+def test_array_constructor_copies_unaligned_inputs():
+    vertices, indices, normals = octahedron_geometry()
+
+    mesh = rs.Mesh(
+        vertices=unaligned_copy(vertices),
+        indices=unaligned_copy(indices),
+        normals=unaligned_copy(normals),
+        material_id=0,
+    )
+
+    np.testing.assert_array_equal(mesh.get_aabb_min(), [-20.0, -20.0, -100.0])
+    np.testing.assert_array_equal(mesh.get_aabb_max(), [20.0, 20.0, -60.0])
+
+
+@pytest.mark.parametrize(
+    ("argument", "value", "message"),
+    [
+        ("vertices", np.zeros((3, 2), dtype=np.float32), r"vertices must have shape \(N, 3\)"),
+        ("vertices", np.zeros((3, 3), dtype=np.float64), "vertices must have dtype float32"),
+        ("indices", np.zeros((3, 2), dtype=np.uint32), r"indices must have shape \(M, 3\)"),
+        (
+            "indices",
+            np.zeros((3, 3), dtype=np.float32),
+            "indices must have dtype uint32, int32, or int64",
+        ),
+        ("normals", np.zeros((3, 2), dtype=np.float32), r"normals must have shape \(N, 3\)"),
+        ("normals", np.zeros((6, 3), dtype=np.float64), "normals must have dtype float32"),
+        (
+            "normals",
+            np.zeros((5, 3), dtype=np.float32),
+            "normals must have the same number of rows as vertices",
+        ),
+    ],
+)
+def test_array_constructor_rejects_shape_and_dtype_errors(argument, value, message):
+    vertices, indices, normals = octahedron_geometry()
+    arguments = {
+        "vertices": vertices,
+        "indices": indices,
+        "normals": normals,
+        "material_id": 0,
+    }
+    arguments[argument] = value
+
+    with pytest.raises(ValueError, match=message):
+        rs.Mesh(**arguments)
+
+
+@pytest.mark.parametrize(
+    ("indices", "message"),
+    [
+        (
+            np.array([[0, -1, 2]], dtype=np.int32),
+            "indices must contain only non-negative values",
+        ),
+        (
+            np.array([[0, 1, np.iinfo(np.uint32).max + 1]], dtype=np.int64),
+            "indices values must fit in uint32",
+        ),
+        (
+            np.array([[0, 1, 6]], dtype=np.uint32),
+            "Mesh: index is out of range for vertices",
+        ),
+    ],
+)
+def test_array_constructor_checks_index_bounds(indices, message):
+    vertices, _, normals = octahedron_geometry()
+
+    with pytest.raises(ValueError, match=message):
+        rs.Mesh(vertices=vertices, indices=indices, normals=normals, material_id=0)
+
+
+@pytest.mark.parametrize(
+    ("vertices", "indices", "message"),
+    [
+        (
+            np.empty((0, 3), dtype=np.float32),
+            np.array([[0, 1, 2]], dtype=np.uint32),
+            "Mesh: vertices must not be empty",
+        ),
+        (
+            np.zeros((3, 3), dtype=np.float32),
+            np.empty((0, 3), dtype=np.uint32),
+            "Mesh: indices must not be empty",
+        ),
+    ],
+)
+def test_array_constructor_rejects_empty_geometry(vertices, indices, message):
+    with pytest.raises(ValueError, match=message):
+        rs.Mesh(vertices=vertices, indices=indices, material_id=0)
+
+
+def write_obj(file_name, vertices, indices, normals):
+    """Write geometry without changing its vertex or normal indexing."""
+    lines = ["o Octahedron"]
+    lines.extend("v " + " ".join(f"{float(value):.9g}" for value in vertex) for vertex in vertices)
+    lines.extend("vn " + " ".join(f"{float(value):.9g}" for value in normal) for normal in normals)
+    lines.extend(
+        "f " + " ".join(f"{int(index) + 1}//{int(index) + 1}" for index in triangle)
+        for triangle in indices
+    )
+    file_name.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def render_mesh(mesh_factory):
+    """Render one small deterministic frame for a supplied mesh factory."""
+    materials = rs.Materials()
+    material_id = materials.get_index("fat")
+    world = rs.World("water")
+    world.add(mesh_factory(material_id))
+
+    simulator = rs.RaytracingUltrasoundSimulator(world, materials)
+    probe = rs.LinearArrayProbe(
+        pose=rs.Pose(
+            position=np.zeros(3, dtype=np.float32),
+            rotation=np.array([0.0, np.pi, 0.0], dtype=np.float32),
+        ),
+        num_elements_x=32,
+        width=40.0,
+        num_el_samples=1,
+    )
+    sim_params = rs.SimParams()
+    sim_params.t_far = 120.0
+    sim_params.buffer_size = 4096
+    sim_params.max_depth = 3
+    sim_params.use_scattering = False
+    sim_params.conv_psf = False
+    sim_params.b_mode_size = (64, 64)
+    return simulator.simulate(probe, sim_params)
+
+
+@pytest.mark.gpu
+def test_array_and_file_meshes_render_identically(tmp_path):
+    vertices, indices, normals = octahedron_geometry()
+    obj_file = tmp_path / "octahedron.obj"
+    write_obj(obj_file, vertices, indices, normals)
+
+    array_image = render_mesh(
+        lambda material_id: rs.Mesh(
+            vertices=vertices,
+            indices=indices,
+            normals=normals,
+            material_id=material_id,
+        )
+    )
+    file_image = render_mesh(lambda material_id: rs.Mesh(str(obj_file), material_id))
+
+    np.testing.assert_allclose(array_image, file_image, rtol=0.0, atol=1e-6)
+
+
+@pytest.mark.gpu
+def test_omitted_normals_produce_a_renderable_mesh():
+    vertices, indices, _ = octahedron_geometry()
+
+    image = render_mesh(
+        lambda material_id: rs.Mesh(
+            vertices=vertices,
+            indices=indices,
+            material_id=material_id,
+        )
+    )
+
+    assert image.shape == (64, 64)


### PR DESCRIPTION
Why this is needed

Host pipelines assembling geometry from USD, Isaac or procedural anatomy currently need to write temporary OBJ files before constructing a raysim mesh. This adds a direct in-memory path for NumPy geometry, avoiding that file-system round trip.

What it does

- Adds a `Mesh` constructor accepting vertices, triangle indices and optional per-vertex normals.
- Stores mesh geometry in host-owned vectors for both file-backed and in-memory construction.
- Uses Assimp only while loading file-backed meshes, preserving the existing validation and error behaviour.
- Normalises supplied normals and rejects zero-length or non-finite values.
- Generates area-weighted per-vertex normals when normals are omitted, rejecting zero or cancelling results.
- Validates array shapes, dtypes, index bounds and normal counts with Python-visible `ValueError`s.
- Uses one shared OptiX/CUDA build path for both construction methods.

The existing file-based constructor and its accepted formats remain unchanged.

Python API

```python
import numpy as np
import raysim.cuda as rs

vertices = np.array(
    [
        [0.0, 0.0, 0.0],
        [1.0, 0.0, 0.0],
        [0.0, 1.0, 0.0],
    ],
    dtype=np.float32,
)
indices = np.array([[0, 1, 2]], dtype=np.uint32)

mesh = rs.Mesh(
    vertices=vertices,
    indices=indices,
    material_id=0,
)
```

`indices` may use `uint32`, `int32` or `int64`. Normals may be supplied as an `(N, 3)` `float32` array; otherwise they are computed automatically.

Geometry extracted from a `UsdGeomMesh` using `usd-core` can be triangulated host-side and passed through the same API. This does not introduce a USD dependency in raysim.

Test coverage

- C++ validation, normal handling and AABB tests for in-memory meshes.
- Regression coverage for rejecting file-backed meshes without normals.
- Python shape, dtype and index validation tests.
- GPU render parity between equivalent file-backed and in-memory meshes.
- GPU smoke coverage for meshes with generated normals.

Validation

- Configured pre-commit hooks
- Release C++/CUDA/Python build
- CTest: 1/1
- Pytest on GPU: 22/22

Non-goals

- No USD dependency in raysim.
- No per-frame geometry updates or GAS refitting.
- No changes to the material API.
