### PR TITLE
fix(fluoro): HU→μ calibration

### DIFF
--- a/fluoro-simulator/README.md
+++ b/fluoro-simulator/README.md
@@ -116,13 +116,22 @@ frame.save("output.png")
 
 ### Step 1: Volume Preprocessing
 
-CT volumes store tissue density in Hounsfield Units (HU). The `VolumePreprocessor` converts these to linear attenuation coefficients (μ in mm⁻¹) using a linear mapping:
+CT volumes store tissue density in Hounsfield Units (HU). The `VolumePreprocessor`
+converts these to linear attenuation coefficients (μ in mm⁻¹) using the default
+60 keV NIST-anchored two-anchor calibration. See the [radiometric calibration
+section](docs/architecture-and-api.md#radiometric-calibration) for anchors and
+physics checks.
 
 ```text
-μ = μ_min + (HU - HU_min) / (HU_max - HU_min) × (μ_max - μ_min)
+μ = μ_water (1 + HU / 1000), HU <= 0
+μ = μ_water + HU (μ_bone - μ_water) / 1500, HU > 0
 ```
 
-Default mapping: HU ∈ [-1000, 3000] → μ ∈ [0.0, 0.02] mm⁻¹
+### Changes
+
+The default HU→μ mapping is now physically calibrated at 60 keV. Rendered
+intensities and contrast change. To reproduce legacy output, use
+`PreprocessingSettings(hu_to_mu=HuToMuMapping())`.
 
 ```python
 # Load from various sources

--- a/fluoro-simulator/docs/architecture-and-api.md
+++ b/fluoro-simulator/docs/architecture-and-api.md
@@ -110,6 +110,27 @@ print(trans.grad)  # ∂L/∂translation
 | `MetricsSettings` | Performance tracking options |
 | `PreprocessingSettings` | HU clipping and mapping settings |
 | `HuToMuMapping` | HU → μ linear mapping parameters |
+| `HuToMuCalibration` | NIST-anchored physical HU → μ calibration |
+
+### Radiometric calibration
+
+The default mapping is physically anchored at 60 keV. For HU <= 0,
+`μ = μ_water (1 + HU / 1000)`; for HU > 0,
+`μ = μ_water + HU (μ_bone - μ_water) / hu_bone_anchor`. The first segment is
+the HU-definition inversion under negligible air attenuation; the second uses
+water and cortical-bone anchors. The bone anchor at 1500 HU
+(`hu_bone_anchor=1500`) is a good median assumption for the input CT calibration.
+
+| Material | Density (g/cm³) | μ/ρ at 60 keV (cm²/g) | μ (mm⁻¹) |
+| --- | ---: | ---: | ---: |
+| Water | 1.000 | 0.2059 | 0.020590 |
+| Cortical bone (ICRU-44) | 1.920 | 0.3148 | 0.060442 |
+| Whole blood (ICRU-44, validation only) | 1.060 | 0.2057 | 0.021804 |
+
+Anchors are from the [NIST XCOM water](https://physics.nist.gov/PhysRefData/XrayMassCoef/ComTab/water.html)
+and [cortical bone](https://physics.nist.gov/PhysRefData/XrayMassCoef/ComTab/bone.html)
+mass attenuation tables (Hubbell & Seltzer; ICRU-44 compositions), retrieved
+2026-08-12. There is no energy interpolation in this version.
 
 ### Key Methods
 

--- a/fluoro-simulator/fluorosim/__init__.py
+++ b/fluoro-simulator/fluorosim/__init__.py
@@ -32,6 +32,7 @@ Example:
     >>> frame = simulator.render_frame(rotation=(0, 0, 0), translation=(0, 0, 0))
 """
 
+from .calibration import HuToMuCalibration
 from .config import (
     CarmGeometry,
     HuToMuMapping,
@@ -56,6 +57,7 @@ __all__ = [
     "MetricsSettings",
     "PreprocessingSettings",
     "HuToMuMapping",
+    "HuToMuCalibration",
     # Volume
     "PreprocessedVolume",
     "VolumePreprocessor",

--- a/fluoro-simulator/fluorosim/calibration.py
+++ b/fluoro-simulator/fluorosim/calibration.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Physically anchored HU-to-linear-attenuation calibration."""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from math import isclose, isfinite
+from typing import Any
+
+import numpy as np
+
+# NIST XCOM, Hubbell and Seltzer mass attenuation tables, retrieved 2026-08-12:
+# https://physics.nist.gov/PhysRefData/XrayMassCoef/ComTab/water.html
+# https://physics.nist.gov/PhysRefData/XrayMassCoef/ComTab/bone.html
+_MU_RHO_WATER_CM2_G: dict[float, float] = {
+    40.0: 0.2683,
+    50.0: 0.2269,
+    60.0: 0.2059,
+    80.0: 0.1837,
+    100.0: 0.1707,
+}
+_MU_RHO_CORTICAL_BONE_CM2_G: dict[float, float] = {
+    40.0: 0.6655,
+    50.0: 0.4242,
+    60.0: 0.3148,
+    80.0: 0.2229,
+    100.0: 0.1855,
+}
+_RHO_WATER_G_CM3: float = 1.0
+_RHO_CORTICAL_BONE_G_CM3: float = 1.92
+_SCHEME = "two_anchor_piecewise_linear_v1"
+_PERMITTED_ENERGIES = frozenset(
+    _MU_RHO_WATER_CM2_G.keys() & _MU_RHO_CORTICAL_BONE_CM2_G.keys()
+)
+
+
+@dataclass(frozen=True)
+class HuToMuCalibration:
+    """Physically anchored piecewise-linear HU-to-μ calibration.
+
+    For HU <= 0, μ = μ_water (1 + HU / 1000).  For HU > 0,
+    μ = μ_water + HU (μ_bone - μ_water) / hu_bone_anchor, with linear
+    extrapolation above the bone anchor.
+
+    The sub-water expression is the algebraic inversion of HU = 1000
+    (μ - μ_water) / (μ_water - μ_air) when μ_air is approximated as zero.
+    At 60 keV μ_air is approximately 2.5e-5 mm^-1 and is negligible here, so
+    this segment is exact under that stated approximation rather than a fitted
+    approximation.  The segments meet continuously at water, with a slope knot.
+    Preprocessing runs in NumPy outside the Slang autodiff path, so the knot has
+    no gradient implication today; it would matter if this mapping moved into an
+    autograd graph.
+
+    ``hu_bone_anchor`` encodes an assumption about the *input CT* calibration,
+    including scanner spectrum and reconstruction kernel.  It is not a universal
+    material constant.
+
+    Anchors use the Hubbell & Seltzer NIST XCOM mass attenuation tables and
+    ICRU-44 water and cortical-bone compositions:
+    https://physics.nist.gov/PhysRefData/XrayMassCoef/ComTab/water.html and
+    https://physics.nist.gov/PhysRefData/XrayMassCoef/ComTab/bone.html.
+
+    Attributes:
+        reference_energy_kev: Tabulated monochromatic reference energy in keV.
+        hu_bone_anchor: CT HU assigned to the cortical-bone anchor.
+        mu_water_override_mm_inv: Optional water attenuation override in mm^-1.
+        mu_bone_override_mm_inv: Optional cortical-bone attenuation override in
+            mm^-1.
+    """
+
+    reference_energy_kev: float = 60.0
+    hu_bone_anchor: float = 1500.0
+    mu_water_override_mm_inv: float | None = None
+    mu_bone_override_mm_inv: float | None = None
+
+    def __post_init__(self) -> None:
+        """Validate tabulated-energy and anchor inputs."""
+        overrides_supplied = (
+            self.mu_water_override_mm_inv is not None
+            and self.mu_bone_override_mm_inv is not None
+        )
+        if not isfinite(self.reference_energy_kev) or self.reference_energy_kev <= 0:
+            raise ValueError("reference_energy_kev must be finite and positive")
+        if not overrides_supplied and self.reference_energy_kev not in _PERMITTED_ENERGIES:
+            permitted = ", ".join(str(energy) for energy in sorted(_PERMITTED_ENERGIES))
+            raise ValueError(
+                "reference_energy_kev must be one of "
+                f"{permitted} keV unless both attenuation overrides are supplied"
+            )
+        if not isfinite(self.hu_bone_anchor) or self.hu_bone_anchor <= 0:
+            raise ValueError("hu_bone_anchor must be finite and greater than zero")
+        for name, value in (
+            ("mu_water_override_mm_inv", self.mu_water_override_mm_inv),
+            ("mu_bone_override_mm_inv", self.mu_bone_override_mm_inv),
+        ):
+            if value is not None and (not isfinite(value) or value <= 0):
+                raise ValueError(f"{name} must be finite and positive when supplied")
+
+    @property
+    def mu_water_mm_inv(self) -> float:
+        """Return the resolved water linear attenuation coefficient in mm^-1."""
+        if self.mu_water_override_mm_inv is not None:
+            return self.mu_water_override_mm_inv
+        return _MU_RHO_WATER_CM2_G[self.reference_energy_kev] * _RHO_WATER_G_CM3 / 10
+
+    @property
+    def mu_bone_mm_inv(self) -> float:
+        """Return the resolved cortical-bone attenuation coefficient in mm^-1."""
+        if self.mu_bone_override_mm_inv is not None:
+            return self.mu_bone_override_mm_inv
+        return (
+            _MU_RHO_CORTICAL_BONE_CM2_G[self.reference_energy_kev]
+            * _RHO_CORTICAL_BONE_G_CM3
+            / 10
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize fields and resolved anchors for volume provenance.
+
+        Returns:
+            Calibration fields, scheme discriminator, and resolved anchors.
+        """
+        return {
+            "scheme": _SCHEME,
+            "reference_energy_kev": self.reference_energy_kev,
+            "hu_bone_anchor": self.hu_bone_anchor,
+            "mu_water_override_mm_inv": self.mu_water_override_mm_inv,
+            "mu_bone_override_mm_inv": self.mu_bone_override_mm_inv,
+            "mu_water_mm_inv": self.mu_water_mm_inv,
+            "mu_bone_mm_inv": self.mu_bone_mm_inv,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "HuToMuCalibration":
+        """Deserialize a calibration and check its informational anchors.
+
+        Args:
+            d: Serialised calibration mapping.
+
+        Returns:
+            Calibration reconstructed from its defining fields.
+
+        Raises:
+            ValueError: If the scheme or a defining field is invalid.
+
+        Warns:
+            RuntimeWarning: If a stored resolved anchor disagrees with the value
+                reconstructed from the defining fields.
+        """
+        if d.get("scheme", _SCHEME) != _SCHEME:
+            raise ValueError(f"Unsupported HU-to-μ calibration scheme: {d.get('scheme')!r}")
+        calibration = cls(
+            reference_energy_kev=float(d["reference_energy_kev"]),
+            hu_bone_anchor=float(d["hu_bone_anchor"]),
+            mu_water_override_mm_inv=(
+                float(d["mu_water_override_mm_inv"])
+                if d.get("mu_water_override_mm_inv") is not None
+                else None
+            ),
+            mu_bone_override_mm_inv=(
+                float(d["mu_bone_override_mm_inv"])
+                if d.get("mu_bone_override_mm_inv") is not None
+                else None
+            ),
+        )
+        for key, resolved in (
+            ("mu_water_mm_inv", calibration.mu_water_mm_inv),
+            ("mu_bone_mm_inv", calibration.mu_bone_mm_inv),
+        ):
+            stored = d.get(key)
+            if stored is None:
+                continue
+            try:
+                matches = isclose(float(stored), resolved, rel_tol=1e-9)
+            except (OverflowError, TypeError, ValueError):
+                matches = False
+            if not matches:
+                warnings.warn(
+                    f"Stored {key}={stored} disagrees with the resolved value {resolved}; "
+                    "using the calibration fields.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+        return calibration
+
+
+def hu_to_mu(hu: np.ndarray, calibration: HuToMuCalibration) -> np.ndarray:
+    """Convert arbitrary-shaped HU data to non-negative float32 attenuation.
+
+    For HU <= 0 this uses μ = μ_water (1 + HU / 1000), the algebraic inversion
+    of HU = 1000 (μ - μ_water) / (μ_water - μ_air) under μ_air ~= 0.  At 60 keV
+    μ_air is approximately 2.5e-5 mm^-1 and negligible, making this segment exact
+    under that approximation.  For HU > 0 it interpolates from water to cortical
+    bone and linearly extrapolates above the bone anchor.  The mapping is C0 at
+    water but has a slope knot.  It runs in NumPy outside the Slang autodiff path,
+    so that knot has no current gradient implication.
+
+    Args:
+        hu: Arbitrary-shaped Hounsfield Unit array.
+        calibration: Physical calibration defining water and bone anchors.
+
+    Returns:
+        Non-negative linear attenuation coefficients in mm^-1 as float32.
+    """
+    values = np.asarray(hu, dtype=np.float32)
+    water = np.float32(calibration.mu_water_mm_inv)
+    bone = np.float32(calibration.mu_bone_mm_inv)
+    bone_slope = (bone - water) / np.float32(calibration.hu_bone_anchor)
+    result = np.empty_like(values, dtype=np.float32)
+    sub_water = values <= np.float32(0.0)
+    above_water = np.logical_not(sub_water)
+
+    np.multiply(values, water / np.float32(1000.0), out=result, where=sub_water)
+    np.add(result, water, out=result, where=sub_water)
+    np.multiply(values, bone_slope, out=result, where=above_water)
+    np.add(result, water, out=result, where=above_water)
+    np.maximum(result, np.float32(0.0), out=result)
+    return result

--- a/fluoro-simulator/fluorosim/config.py
+++ b/fluoro-simulator/fluorosim/config.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+from .calibration import HuToMuCalibration
+
 
 @dataclass(frozen=True)
 class CarmGeometry:
@@ -148,6 +150,9 @@ class HuToMuMapping:
 
     Defines the linear mapping from HU values to μ (mm⁻¹) for X-ray simulation.
 
+    No longer used by default. Retained for reproducing legacy output; it is not
+    physically calibrated. See ``HuToMuCalibration``.
+
     Attributes:
         hu_min: Minimum HU value (maps to mu_min). Default: -1000 (air).
         hu_max: Maximum HU value (maps to mu_max). Default: 3000 (dense bone).
@@ -235,7 +240,9 @@ class PreprocessingSettings:
     hu_clip_min: float = -1024.0
     hu_clip_max: float = 3071.0
     clip_hu: bool = True
-    hu_to_mu: HuToMuMapping = field(default_factory=HuToMuMapping)
+    hu_to_mu: HuToMuCalibration | HuToMuMapping = field(
+        default_factory=HuToMuCalibration
+    )
 
 
 @dataclass(frozen=True)

--- a/fluoro-simulator/fluorosim/ct/__init__.py
+++ b/fluoro-simulator/fluorosim/ct/__init__.py
@@ -17,7 +17,7 @@
 
 Notes:
 - The default ingestion CLIs are plain Python modules.
-- HU → μ conversion is handled by VolumePreprocessor using HuToMuMapping from config.py.
+- HU → μ conversion is handled by VolumePreprocessor using HuToMuCalibration.
 """
 
 from fluorosim.ct.dicom_ingest import CtVolume, load_dicom_series_hu, load_nifti_hu

--- a/fluoro-simulator/fluorosim/preprocessor.py
+++ b/fluoro-simulator/fluorosim/preprocessor.py
@@ -21,8 +21,11 @@ CT volumes from DICOM or NIfTI sources into a format suitable for rendering.
 
 from __future__ import annotations
 
+import importlib
 import warnings
+from importlib import metadata
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -228,6 +231,7 @@ class VolumePreprocessor:
             hu_range=hu_range,
             mu_range=mu_range,
             source=self._source,
+            calibration=self._calibration_metadata(settings.hu_to_mu),
         )
 
         # Create volume
@@ -270,6 +274,37 @@ class VolumePreprocessor:
             mu_float32: np.ndarray = mu.astype(np.float32)
             return mu_float32
         raise TypeError(f"Unsupported HU-to-μ configuration: {type(cfg).__name__}")
+
+    @staticmethod
+    def _calibration_metadata(
+        cfg: HuToMuCalibration | HuToMuMapping,
+    ) -> dict[str, Any]:
+        """Return self-describing provenance for a saved attenuation volume."""
+        if isinstance(cfg, HuToMuCalibration):
+            provenance = cfg.to_dict()
+            provenance["package_version"] = VolumePreprocessor._package_version()
+            return provenance
+        if isinstance(cfg, HuToMuMapping):
+            return {
+                "scheme": "legacy_minmax",
+                "hu_min": cfg.hu_min,
+                "hu_max": cfg.hu_max,
+                "mu_min": cfg.mu_min,
+                "mu_max": cfg.mu_max,
+            }
+        raise TypeError(f"Unsupported HU-to-μ configuration: {type(cfg).__name__}")
+
+    @staticmethod
+    def _package_version() -> str:
+        """Resolve the package version without requiring an installed source tree."""
+        package = importlib.import_module("fluorosim")
+        version = getattr(package, "__version__", None)
+        if version is not None:
+            return str(version)
+        try:
+            return metadata.version("fluorosim")
+        except metadata.PackageNotFoundError:
+            return "unknown"
 
     def __repr__(self) -> str:
         z, y, x = self.shape

--- a/fluoro-simulator/fluorosim/preprocessor.py
+++ b/fluoro-simulator/fluorosim/preprocessor.py
@@ -21,10 +21,12 @@ CT volumes from DICOM or NIfTI sources into a format suitable for rendering.
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import numpy as np
 
+from .calibration import HuToMuCalibration, hu_to_mu
 from .config import HuToMuMapping, PreprocessingSettings
 from .volume import PreprocessedVolume, VolumeMetadata
 
@@ -174,7 +176,8 @@ class VolumePreprocessor:
     @property
     def shape(self) -> tuple[int, int, int]:
         """Return volume shape (Z, Y, X)."""
-        return self._hu_volume.shape
+        z, y, x = self._hu_volume.shape
+        return (int(z), int(y), int(x))
 
     @property
     def spacing_zyx_mm(self) -> tuple[float, float, float]:
@@ -237,23 +240,36 @@ class VolumePreprocessor:
 
         return volume
 
-    def _hu_to_mu(self, hu: np.ndarray, cfg: HuToMuMapping) -> np.ndarray:
-        """Convert Hounsfield Units to linear attenuation coefficient (μ).
+    def _hu_to_mu(
+        self, hu: np.ndarray, cfg: HuToMuCalibration | HuToMuMapping
+    ) -> np.ndarray:
+        """Convert Hounsfield Units to linear attenuation coefficients.
 
-        Uses a linear mapping:
-            μ = μ_min + (HU - HU_min) / (HU_max - HU_min) × (μ_max - μ_min)
+        Dispatches to the physical two-anchor calibration or the retained
+        legacy min-max mapping according to ``cfg``.
 
         Args:
             hu: HU volume array.
-            cfg: Mapping configuration.
+            cfg: Physical calibration or legacy mapping configuration.
 
         Returns:
             μ volume as float32 array.
         """
-        hu_clipped = np.clip(hu, cfg.hu_min, cfg.hu_max)
-        t = (hu_clipped - cfg.hu_min) / (cfg.hu_max - cfg.hu_min + 1e-12)
-        mu = cfg.mu_min + t * (cfg.mu_max - cfg.mu_min)
-        return mu.astype(np.float32)
+        if isinstance(cfg, HuToMuCalibration):
+            return hu_to_mu(hu, cfg)
+        if isinstance(cfg, HuToMuMapping):
+            warnings.warn(
+                "HuToMuMapping is retained only for legacy reproduction and will be "
+                "removed in v0.3; use HuToMuCalibration instead.",
+                FutureWarning,
+                stacklevel=3,
+            )
+            hu_clipped = np.clip(hu, cfg.hu_min, cfg.hu_max)
+            t = (hu_clipped - cfg.hu_min) / (cfg.hu_max - cfg.hu_min + 1e-12)
+            mu = cfg.mu_min + t * (cfg.mu_max - cfg.mu_min)
+            mu_float32: np.ndarray = mu.astype(np.float32)
+            return mu_float32
+        raise TypeError(f"Unsupported HU-to-μ configuration: {type(cfg).__name__}")
 
     def __repr__(self) -> str:
         z, y, x = self.shape

--- a/fluoro-simulator/fluorosim/volume.py
+++ b/fluoro-simulator/fluorosim/volume.py
@@ -41,6 +41,7 @@ class VolumeMetadata:
         hu_range: Original HU range before conversion [min, max].
         mu_range: μ range after conversion [min, max].
         source: Original source path (DICOM dir or NIfTI file).
+        calibration: Calibration provenance used to create the μ volume.
     """
 
     shape_zyx: tuple[int, int, int]
@@ -49,6 +50,7 @@ class VolumeMetadata:
     hu_range: tuple[float, float] | None = None
     mu_range: tuple[float, float] | None = None
     source: str | None = None
+    calibration: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -59,6 +61,7 @@ class VolumeMetadata:
             "hu_range": list(self.hu_range) if self.hu_range else None,
             "mu_range": list(self.mu_range) if self.mu_range else None,
             "source": self.source,
+            "calibration": self.calibration,
         }
 
     @classmethod
@@ -71,6 +74,7 @@ class VolumeMetadata:
             hu_range=tuple(d["hu_range"]) if d.get("hu_range") else None,
             mu_range=tuple(d["mu_range"]) if d.get("mu_range") else None,
             source=d.get("source"),
+            calibration=d.get("calibration"),
         )
 
 
@@ -127,7 +131,8 @@ class PreprocessedVolume:
     @property
     def shape(self) -> tuple[int, int, int]:
         """Return volume shape (Z, Y, X)."""
-        return self._mu_volume.shape
+        z, y, x = self._mu_volume.shape
+        return (int(z), int(y), int(x))
 
     @property
     def spacing_zyx_mm(self) -> tuple[float, float, float]:

--- a/fluoro-simulator/tests/test_calibration.py
+++ b/fluoro-simulator/tests/test_calibration.py
@@ -18,8 +18,11 @@
 from __future__ import annotations
 
 import math
+import warnings
+
 import numpy as np
 import pytest
+from fluorosim import HuToMuMapping, PreprocessingSettings, VolumePreprocessor
 from fluorosim.calibration import HuToMuCalibration, hu_to_mu
 
 
@@ -122,8 +125,33 @@ def test_serialization_warns_on_informational_anchor_mismatch() -> None:
 
 
 def test_units_oracle_300_mm_water() -> None:
-    """The physical mapping produces the closed-form water transmission."""
+    """The default full chain produces the closed-form water transmission."""
     hu = np.zeros((1, 300, 1), dtype=np.float32)
-    mu = hu_to_mu(hu, HuToMuCalibration())
-    transmission = math.exp(-float(np.sum(mu[0, :, 0])))
+    volume = VolumePreprocessor.from_numpy(
+        hu, spacing_zyx_mm=(1.0, 1.0, 1.0), settings=PreprocessingSettings()
+    ).preprocess()
+    transmission = math.exp(-float(np.sum(volume.mu_volume[0, :, 0])))
     assert transmission == pytest.approx(2.077e-3, rel=1e-3)
+
+
+def test_legacy_mapping_is_bit_identical_and_warns() -> None:
+    """An explicit legacy request keeps the original formula and signals migration."""
+    hu = np.array([[[-1024.0, -1000.0, 0.0, 3000.0, 3071.0]]], dtype=np.float32)
+    mapping = HuToMuMapping()
+    with pytest.warns(FutureWarning, match="HuToMuCalibration"):
+        result = VolumePreprocessor.from_numpy(
+            hu, settings=PreprocessingSettings(hu_to_mu=mapping)
+        ).preprocess().mu_volume
+    clipped = np.clip(np.clip(hu, -1024.0, 3071.0), mapping.hu_min, mapping.hu_max)
+    expected = mapping.mu_min + (clipped - mapping.hu_min) / (
+        mapping.hu_max - mapping.hu_min + 1e-12
+    ) * (mapping.mu_max - mapping.mu_min)
+    np.testing.assert_array_equal(result, expected.astype(np.float32))
+
+
+def test_default_is_calibrated_and_warning_free() -> None:
+    """The public preprocessing default selects the physical, warning-free path."""
+    assert isinstance(PreprocessingSettings().hu_to_mu, HuToMuCalibration)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        VolumePreprocessor.from_numpy(np.zeros((1, 1, 1), dtype=np.float32)).preprocess()

--- a/fluoro-simulator/tests/test_calibration.py
+++ b/fluoro-simulator/tests/test_calibration.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Non-GPU physics and structural tests for HU-to-μ calibration."""
+
+from __future__ import annotations
+
+import math
+import numpy as np
+import pytest
+from fluorosim.calibration import HuToMuCalibration, hu_to_mu
+
+
+def test_water_anchor() -> None:
+    """Water at 0 HU resolves to the NIST 60 keV anchor."""
+    result = hu_to_mu(np.array([0.0]), HuToMuCalibration())
+    assert float(result[0]) == pytest.approx(0.020590, rel=1e-6)
+
+
+def test_bone_anchor() -> None:
+    """The bone CT anchor resolves to the unrounded NIST-derived value."""
+    result = hu_to_mu(np.array([1500.0]), HuToMuCalibration())
+    assert float(result[0]) == pytest.approx(0.3148 * 1.92 / 10, rel=1e-6)
+
+
+def test_air() -> None:
+    """Air maps exactly to zero attenuation."""
+    assert float(hu_to_mu(np.array([-1000.0]), HuToMuCalibration())[0]) == 0.0
+
+
+def test_subair_clamped() -> None:
+    """Below-air scanner padding is clamped rather than becoming negative μ."""
+    result = hu_to_mu(np.linspace(-1024.0, 3071.0, 2048), HuToMuCalibration())
+    assert result[0] == 0.0
+    assert np.all(result >= 0.0)
+
+
+def test_blood_out_of_sample() -> None:
+    """Validate the two-anchor approximation against independent NIST blood data."""
+    # Blood is deliberately not an anchor; this validates the approximation.
+    result = hu_to_mu(np.array([50.0]), HuToMuCalibration())
+    assert float(result[0]) == pytest.approx(0.021804, rel=0.02)
+
+
+@pytest.mark.parametrize("energy", [40.0, 50.0, 60.0, 80.0, 100.0])
+def test_mapping_is_monotone(energy: float) -> None:
+    """Each tabulated monochromatic mapping is non-decreasing in HU."""
+    result = hu_to_mu(np.linspace(-1024.0, 3071.0, 10000), HuToMuCalibration(energy))
+    assert np.all(np.diff(result) >= 0.0)
+
+
+def test_continuity_at_water() -> None:
+    """The production mapping has no jump at water."""
+    calibration = HuToMuCalibration()
+    epsilon = 1e-6
+    result = hu_to_mu(np.array([-epsilon, epsilon]), calibration)
+    assert abs(float(result[0]) - float(result[1])) < 1e-9
+
+
+def test_above_anchor_extrapolates_linearly() -> None:
+    """Dense materials do not plateau at the cortical-bone anchor."""
+    calibration = HuToMuCalibration()
+    expected = calibration.mu_water_mm_inv + 3000.0 * (
+        calibration.mu_bone_mm_inv - calibration.mu_water_mm_inv
+    ) / calibration.hu_bone_anchor
+    assert float(hu_to_mu(np.array([3000.0]), calibration)[0]) == pytest.approx(expected)
+
+
+def test_validation_and_overrides() -> None:
+    """Table validation rejects unknown energies while paired overrides bypass it."""
+    with pytest.raises(ValueError, match=r"40\.0, 50\.0, 60\.0, 80\.0, 100\.0"):
+        HuToMuCalibration(65.0)
+    with pytest.raises(ValueError, match="greater than zero"):
+        HuToMuCalibration(hu_bone_anchor=0.0)
+    assert HuToMuCalibration(65.0, mu_water_override_mm_inv=0.02, mu_bone_override_mm_inv=0.06)
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0, math.nan, math.inf, -math.inf])
+def test_non_finite_or_non_positive_inputs_are_rejected(value: float) -> None:
+    """Physical inputs must be finite and positive."""
+    with pytest.raises(ValueError, match="reference_energy_kev"):
+        HuToMuCalibration(
+            reference_energy_kev=value,
+            mu_water_override_mm_inv=0.02,
+            mu_bone_override_mm_inv=0.06,
+        )
+    with pytest.raises(ValueError, match="hu_bone_anchor"):
+        HuToMuCalibration(hu_bone_anchor=value)
+    with pytest.raises(ValueError, match="mu_water_override_mm_inv"):
+        HuToMuCalibration(mu_water_override_mm_inv=value)
+    with pytest.raises(ValueError, match="mu_bone_override_mm_inv"):
+        HuToMuCalibration(mu_bone_override_mm_inv=value)
+
+
+def test_serialization_roundtrip() -> None:
+    """Calibration fields and resolved anchors round-trip through provenance data."""
+    calibration = HuToMuCalibration(80.0, 1200.0)
+    assert HuToMuCalibration.from_dict(calibration.to_dict()) == calibration
+
+
+def test_serialization_warns_on_informational_anchor_mismatch() -> None:
+    """Defining fields win when stored resolved values are stale or edited."""
+    calibration = HuToMuCalibration()
+    payload = calibration.to_dict()
+    for stale_value in (1.0, "not-a-number"):
+        payload["mu_water_mm_inv"] = stale_value
+        with pytest.warns(RuntimeWarning, match="disagrees with the resolved value"):
+            restored = HuToMuCalibration.from_dict(payload)
+        assert restored == calibration
+
+
+def test_units_oracle_300_mm_water() -> None:
+    """The physical mapping produces the closed-form water transmission."""
+    hu = np.zeros((1, 300, 1), dtype=np.float32)
+    mu = hu_to_mu(hu, HuToMuCalibration())
+    transmission = math.exp(-float(np.sum(mu[0, :, 0])))
+    assert transmission == pytest.approx(2.077e-3, rel=1e-3)

--- a/fluoro-simulator/tests/test_calibration.py
+++ b/fluoro-simulator/tests/test_calibration.py
@@ -155,3 +155,40 @@ def test_default_is_calibrated_and_warning_free() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", FutureWarning)
         VolumePreprocessor.from_numpy(np.zeros((1, 1, 1), dtype=np.float32)).preprocess()
+
+
+@pytest.mark.gpu
+def test_renderer_differential_water_slabs() -> None:
+    """A geometry-independent renderer ratio preserves μ times added thickness."""
+    slangpy = pytest.importorskip("slangpy")
+    try:
+        slangpy.create_device(slangpy.DeviceType.cuda)
+    except Exception as error:  # Device creation failures are environment-dependent.
+        pytest.skip(f"Slang renderer unavailable: {error}")
+
+    from fluorosim.rendering.diffdrr_slang_renderer import SlangDiffDRRConfig, SlangDiffDRRRenderer
+
+    calibration = HuToMuCalibration()
+    cfg = SlangDiffDRRConfig(
+        det_height_px=8,
+        det_width_px=8,
+        step_mm=0.25,
+        i0=1.0,
+        normalize=False,
+        invert=False,
+    )
+    renderer_50 = SlangDiffDRRRenderer(
+        np.full((50, 8, 8), calibration.mu_water_mm_inv, dtype=np.float32),
+        (1.0, 1.0, 1.0),
+        cfg,
+    )
+    renderer_100 = SlangDiffDRRRenderer(
+        np.full((100, 8, 8), calibration.mu_water_mm_inv, dtype=np.float32),
+        (1.0, 1.0, 1.0),
+        cfg,
+    )
+    intensity_50 = float(renderer_50.render()[4, 4])
+    intensity_100 = float(renderer_100.render()[4, 4])
+    assert math.log(intensity_50 / intensity_100) == pytest.approx(
+        calibration.mu_water_mm_inv * 50.0, rel=0.02
+    )

--- a/fluoro-simulator/tests/test_preprocessor.py
+++ b/fluoro-simulator/tests/test_preprocessor.py
@@ -17,7 +17,7 @@
 
 import numpy as np
 import pytest
-from fluorosim import PreprocessedVolume, VolumePreprocessor
+from fluorosim import HuToMuMapping, PreprocessedVolume, PreprocessingSettings, VolumeMetadata, VolumePreprocessor
 
 
 class TestVolumePreprocessor:
@@ -74,6 +74,19 @@ class TestVolumePreprocessor:
         volume = preprocessor.preprocess()
 
         assert volume.metadata.spacing_zyx_mm == sample_spacing
+        assert volume.metadata.calibration is not None
+        assert volume.metadata.calibration["scheme"] == "two_anchor_piecewise_linear_v1"
+
+    def test_legacy_mapping_records_provenance(self, sample_hu_volume, sample_spacing):
+        """Explicit legacy processing records the old mapping parameters."""
+        with pytest.warns(FutureWarning):
+            volume = VolumePreprocessor.from_numpy(
+                sample_hu_volume,
+                spacing_zyx_mm=sample_spacing,
+                settings=PreprocessingSettings(hu_to_mu=HuToMuMapping()),
+            ).preprocess()
+        assert volume.metadata.calibration is not None
+        assert volume.metadata.calibration["scheme"] == "legacy_minmax"
 
 
 class TestPreprocessedVolume:
@@ -99,11 +112,26 @@ class TestPreprocessedVolume:
         assert loaded.mu_volume.shape == original.mu_volume.shape
         np.testing.assert_array_almost_equal(loaded.mu_volume, original.mu_volume)
         assert loaded.metadata.spacing_zyx_mm == original.metadata.spacing_zyx_mm
+        assert loaded.metadata.calibration == original.metadata.calibration
 
     def test_load_nonexistent_raises(self, temp_cache_dir):
         """Test that loading a nonexistent volume raises an error."""
         with pytest.raises((FileNotFoundError, ValueError)):
             PreprocessedVolume.load(temp_cache_dir / "nonexistent")
+
+    def test_legacy_metadata_without_calibration_loads(self):
+        """Metadata files written before calibration provenance remain readable."""
+        legacy = {
+            "shape_zyx": [1, 2, 3],
+            "spacing_zyx_mm": [1.0, 1.0, 1.0],
+            "origin_xyz_mm": None,
+            "hu_range": [-1000.0, 1000.0],
+            "mu_range": [0.0, 0.02],
+            "source": "legacy",
+        }
+        metadata = VolumeMetadata.from_dict(legacy)
+        assert metadata.calibration is None
+        assert VolumeMetadata.from_dict(metadata.to_dict()).calibration is None
 
 
 class TestEdgeCases:

--- a/fluoro-simulator/tests/test_preprocessor.py
+++ b/fluoro-simulator/tests/test_preprocessor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,6 +57,14 @@ class TestVolumePreprocessor:
 
         # Check dtype is float32
         assert volume.mu_volume.dtype == np.float32
+
+        water = 0.020590
+        bone = 0.3148 * 1.92 / 10
+        assert float(volume.mu_volume[0, 0, 0]) == pytest.approx(water * 0.1, rel=1e-4)
+        assert float(volume.mu_volume[8, 16, 16]) == pytest.approx(
+            water + 800.0 * (bone - water) / 1500.0,
+            rel=1e-4,
+        )
 
     def test_metadata_preserved(self, sample_hu_volume, sample_spacing):
         """Test that spacing metadata is preserved."""


### PR DESCRIPTION
## What's wrong

The previous min–max default maps water (0 HU) to 0.005 mm⁻¹ instead of the
NIST 60 keV value 0.020590 mm⁻¹. As Beer–Lambert is exponential, 300 mm of
water transmitted 0.22313 under the old default versus 2.077 × 10⁻³ physically,
a factor of about 108. The old mapping cannot be fixed by a global gain: bone
and water have different scale errors. In the local CTChest AP comparison,
the minimum current whole-torso transmission was 0.183. With the fix it is
6.98 × 10⁻⁴, about 263x lower. 

| Material | μ at 60 keV (mm⁻¹) |
| --- | ---: |
| Water | 0.020590 |
| Cortical bone (ICRU-44) | 0.060442 |
| Whole blood (independent validation) | 0.021804 |

| Water check | Current | Fixed |
| --- | ---: | ---: |
| HVL | 138.63 mm | 33.664 mm |
| T through 300 mm | 0.22313 | 2.077 × 10⁻³ |

## Comparison render

Ex facie, the current output looks 'better', but this is misleading.
Linear-T view makes the current output look crisper: feature contrast is
`T ΔA`, so the wrong mapping acts as a dynamic-range compressor (current
`A <= 1.7` versus correct `A` up to about 7.3). Real imaging uses film H&D or
digital log/gamma/windowing, which is linear in `A=-ln(T)`. Per-image
normalisation makes `minmax(cA) = minmax(A)`, hiding a uniform μ error. Only an
absolute shared-scale comparison reveals the physical difference. 

<img width="848" height="414" alt="image" src="https://github.com/user-attachments/assets/98dcfb35-0751-4392-a152-35440aa4b73d" />




## Test strategy

Non-GPU tests cover NIST water/bone anchors, independent blood validation,
monotonicity, air and scanner-padding clamp, extrapolation, serialisation,
current-path byte identity plus `FutureWarning`, default warning-free behaviour,
metadata compatibility, and a units oracle. The oracle preprocesses 300 voxels
of water and asserts `exp(-sum(μ)·1 mm) = 2.077e-3`; its absence is what allowed the
fourfold μ oopsie to survive. 

## Eventually...

...this will be wrapped into a multienergy approach. A lot of the issues here arose because 
we are assuming monochromatic X-ray light, which of course is not the case at all. This is 
the root of many issues with the fluoro module at large, including the lack of beam hardening.